### PR TITLE
Building working Linux wheels

### DIFF
--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -40,10 +40,10 @@ jobs:
             python=${{ matrix.python-version }}
           init-shell: bash
 
-#      - name: "Install dependencies with pip"
-#        shell: bash -l {0}
-#        run: |
-#          pip install -v --pre -r devtools/requirements/${{ matrix.requirements }}.txt
+      - name: "Install dependencies with pip"
+        shell: bash -l {0}
+        run: |
+          pip install -v --pre -r devtools/requirements/${{ matrix.requirements }}.txt
 
       - name: "Install dependencies with yum"
         run: |
@@ -60,9 +60,7 @@ jobs:
       - name: "See what's available in cuda"
         shell: bash -l {0}
         run: |
-          find /usr/local/cuda || true
-          find /usr/local/lib/cuda || true
-          find /usr/lib || true
+          find / -iname "cuda" || true
           false
 
 #      - name: "Install HIP"

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -16,7 +16,6 @@ jobs:
   linux:
     runs-on: ${{ matrix.os }}
     container:
-      # Use a version of manylinux with GCC 13, not 14, for NVCC compatibility
       image: quay.io/pypa/manylinux_2_28_x86_64:2024.11.23-1
     name: "${{ matrix.name }} ${{ matrix.python-version }}"
     strategy:
@@ -26,7 +25,7 @@ jobs:
           - name: Linux x86
             os: ubuntu-latest
             requirements: linux
-            cuda-version: "12-6"
+            cuda-version: "12-4"
             cuda-arch: "x86_64"
             hip-version: "6"
 
@@ -57,11 +56,11 @@ jobs:
                          cuda-libraries-devel-${{ matrix.cuda-version }}.${{ matrix.cuda-arch }} \
                          cuda-nvtx-${{ matrix.cuda-version }}.${{ matrix.cuda-arch }}
 
-      - name: "Install HIP"
-        run: |
-          yum install -y epel-release
-          yum install -y https://repo.radeon.com/amdgpu-install/6.2.2/el/8.10/amdgpu-install-6.2.60202-1.el8.noarch.rpm
-          yum install -y rocm-device-libs hip-devel hip-runtime-amd hipcc
+#      - name: "Install HIP"
+#        run: |
+#          yum install -y epel-release
+#          yum install -y https://repo.radeon.com/amdgpu-install/6.2.2/el/8.10/amdgpu-install-6.2.60202-1.el8.noarch.rpm
+#          yum install -y rocm-device-libs hip-devel hip-runtime-amd hipcc
 
       - name: "Check out OpenMM-Torch source code"
         run: |
@@ -85,7 +84,6 @@ jobs:
             -DCMAKE_CXX_FLAGS='-D_GLIBCXX_USE_CXX11_ABI=0 -Wl,--allow-shlib-undefined' \
             -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
             -DCMAKE_CUDA_HOST_COMPILER=c++ \
-            -DCMAKE_PREFIX_PATH=/opt/rocm \
             -DOPENCL_INCLUDE_DIR=/usr/include/CL \
             -DOPENCL_LIBRARY=/usr/lib64/libOpenCL.so.1
 
@@ -102,7 +100,6 @@ jobs:
           cd openmm-torch/build/python
           export OPENMM_TORCH_VERSION=$(echo $(grep "OPENMM_TORCH_VERSION:" $GITHUB_WORKSPACE/openmm-torch/build/CMakeCache.txt) | cut -d '=' -f2)$VERSION_SUFFIX
           export CUDA_VERSION=$(cut -d '-' -f1 <<< ${{ matrix.cuda-version }})
-          export HIP_VERSION=${{ matrix.hip-version }}
           pip wheel -w dist .
           cd dist
           export SITE_PACKAGES=$(python -c 'import site; print(site.getsitepackages()[0])')
@@ -146,7 +143,6 @@ jobs:
           cd $GITHUB_WORKSPACE/devtools/cuda
           export OPENMM_TORCH_VERSION=$(echo $(grep "OPENMM_TORCH_VERSION:" $GITHUB_WORKSPACE/openmm-torch/build/CMakeCache.txt) | cut -d '=' -f2)$VERSION_SUFFIX
           export CUDA_VERSION=$(cut -d '-' -f1 <<< ${{ matrix.cuda-version }})
-          export HIP_VERSION=${{ matrix.hip-version }}
           pip wheel -w dist .
           cd dist
           export SITE_PACKAGES=$(python -c 'import site; print(site.getsitepackages()[0])')
@@ -177,8 +173,6 @@ jobs:
           python -m venv "${HOME}/test_env"
           source "${HOME}/test_env/bin/activate"
           cd openmm-torch/build
-          #export CUDA_VERSION=$(cut -d '-' -f1 <<< ${{ matrix.cuda-version }})
-          #pip install --pre -f python/dist/fixed openmmtorch[cuda${CUDA_VERSION}]
           pip install --pre -f python/dist/fixed openmmtorch
           ls -l python/dist/fixed
           python -c "import openmmtorch; f = openmmtorch.TorchForce('tests/forces.pt')"

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -40,10 +40,10 @@ jobs:
             python=${{ matrix.python-version }}
           init-shell: bash
 
-      - name: "Install dependencies with pip"
-        shell: bash -l {0}
-        run: |
-          pip install -v --pre -r devtools/requirements/${{ matrix.requirements }}.txt
+#      - name: "Install dependencies with pip"
+#        shell: bash -l {0}
+#        run: |
+#          pip install -v --pre -r devtools/requirements/${{ matrix.requirements }}.txt
 
       - name: "Install dependencies with yum"
         run: |
@@ -56,6 +56,14 @@ jobs:
                          cuda-libraries-${{ matrix.cuda-version }}.${{ matrix.cuda-arch }} \
                          cuda-libraries-devel-${{ matrix.cuda-version }}.${{ matrix.cuda-arch }} \
                          cuda-nvtx-${{ matrix.cuda-version }}.${{ matrix.cuda-arch }}
+
+      - name: "See what's available in cuda"
+        shell: bash -l {0}
+        run: |
+          find /usr/local/cuda || true
+          find /usr/local/lib/cuda || true
+          find /usr/lib || true
+          false
 
 #      - name: "Install HIP"
 #        run: |
@@ -180,7 +188,7 @@ jobs:
           #pip install --pre -f python/dist/fixed openmmtorch[cuda${CUDA_VERSION}]
           pip install --pre -f python/dist/fixed openmmtorch
           ls -l python/dist/fixed
-          python -c "import openmmtorch; f = openmmtorch.TorchForce('tests/forces.pt')" || true
+          python -c "import openmmtorch; f = openmmtorch.TorchForce('tests/forces.pt')"
 
       - name: "Upload the wheel"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -60,7 +60,8 @@ jobs:
       - name: "See what's available in cuda"
         shell: bash -l {0}
         run: |
-          find / -iname '*cuda*' || true
+          readlink -f /usr/local/cuda
+          find -L $(readlink -f /usr/local/cuda)
           false
 
 #      - name: "Install HIP"

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: "Install dependencies with yum"
         run: |
-          yum -y install zip opencl-headers ocl-icd
+          yum -y install zip opencl-headers ocl-icd tree
 
       - name: "Install CUDA"
         run: |
@@ -71,6 +71,11 @@ jobs:
           git apply $GITHUB_WORKSPACE/devtools/patches/cxx11_abi.patch
           git apply $GITHUB_WORKSPACE/devtools/patches/extras_require.patch
 
+      - name: "Tell me everything in the system"
+        run: |
+          cd /
+          tree || true
+
       - name: "Configure build with CMake"
         shell: bash -l {0}
         run: |
@@ -87,7 +92,8 @@ jobs:
             -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
             -DCMAKE_CUDA_HOST_COMPILER=c++ \
             -DOPENCL_INCLUDE_DIR=/usr/include/CL \
-            -DOPENCL_LIBRARY=/usr/lib64/libOpenCL.so.1
+            -DOPENCL_LIBRARY=/usr/lib64/libOpenCL.so.1 \
+            -DUSE_SYSTEM_NVTX
 
       - name: "Build OpenMM-Torch"
         shell: bash -l {0}
@@ -179,9 +185,9 @@ jobs:
           ls -l python/dist/fixed
 #          python -c "import openmmtorch; f = openmmtorch.TorchForce('tests/forces.pt')"
 
-      - name: "Upload the wheel"
-        uses: actions/upload-artifact@v4
-        with:
-          name: openmm-torch-wheel-linux-${{matrix.python-version}}
-          path: openmm-torch/build/python/dist/fixed
-          retention-days: 10
+          # - name: "Upload the wheel"
+          #   uses: actions/upload-artifact@v4
+          #   with:
+          #     name: openmm-torch-wheel-linux-${{matrix.python-version}}
+          #     path: openmm-torch/build/python/dist/fixed
+          #     retention-days: 10

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -84,7 +84,7 @@ jobs:
             -DCMAKE_CXX_FLAGS='-D_GLIBCXX_USE_CXX11_ABI=0' \
             -DCMAKE_CUDA_ARCHITECTURES=OFF \
             -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
-            -DCMAKE_CUDA_HOST_COMPILER=c++ \
+            -DCMAKE_CUDA_HOST_COMPILER=g++-13 \
             -DOPENCL_INCLUDE_DIR=/usr/include/CL \
             -DOPENCL_LIBRARY=/usr/lib64/libOpenCL.so.1
 

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -44,7 +44,7 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install -v --pre -r devtools/requirements/${{ matrix.requirements }}.txt
-          pip install -v torch==2.3
+          pip install -v torch==2.6
 
       - name: "Install dependencies with yum"
         run: |

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -47,7 +47,8 @@ jobs:
 
       - name: "Install dependencies with yum"
         run: |
-          yum -y install zip opencl-headers ocl-icd
+          apt install -y zip opencl-headers ocl-icd gcc-13
+          update-alternatives --query gcc
 
       - name: "Install CUDA"
         run: |
@@ -84,7 +85,7 @@ jobs:
             -DCMAKE_CXX_FLAGS='-D_GLIBCXX_USE_CXX11_ABI=0' \
             -DCMAKE_CUDA_ARCHITECTURES=OFF \
             -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
-            -DCMAKE_CUDA_HOST_COMPILER=g++-13 \
+            -DCMAKE_CUDA_HOST_COMPILER=c++ \
             -DOPENCL_INCLUDE_DIR=/usr/include/CL \
             -DOPENCL_LIBRARY=/usr/lib64/libOpenCL.so.1
 

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -178,7 +178,7 @@ jobs:
           pip install --pre -f python/dist/fixed openmmtorch[cuda${CUDA_VERSION}]
           python -m openmm.testInstallation
           cd ../python/tests
-          for test_file in Test*.py; do pytest "${test_file}"; done
+          pytest -k "not testTorchANI" Test*.py
 
       - name: "Upload the wheel"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -121,6 +121,7 @@ jobs:
             --exclude libtorch_gpu.so \
             --exclude libtorch_cuda.so \
             --exclude libc10.so \
+            --exclude libc10_cuda.so \
             --exclude libcuda.so.1 \
             --exclude libcudart.so.12 \
             --exclude libcufft.so.11 \

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -173,9 +173,12 @@ jobs:
           python -m venv "${HOME}/test_env"
           source "${HOME}/test_env/bin/activate"
           cd openmm-torch/build
-          pip install --pre -f python/dist/fixed openmmtorch
-          ls -l python/dist/fixed
+          export CUDA_VERSION=$(cut -d '-' -f1 <<< ${{ matrix.cuda-version }})
+          pip install --pre -f python/dist/fixed openmmtorch[cuda${CUDA_VERSION}]
           python -c "import openmmtorch; f = openmmtorch.TorchForce('tests/forces.pt')"
+          cd
+          cd openmm-torch/python/tests
+          for test_file in Test*.py; do pytest "${test_file}"; done
 
       - name: "Upload the wheel"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -55,7 +55,8 @@ jobs:
           dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/${{ matrix.cuda-arch }}/cuda-rhel8.repo
           dnf -y install cuda-compiler-${{ matrix.cuda-version }}.${{ matrix.cuda-arch }} \
                          cuda-libraries-${{ matrix.cuda-version }}.${{ matrix.cuda-arch }} \
-                         cuda-libraries-devel-${{ matrix.cuda-version }}.${{ matrix.cuda-arch }}
+                         cuda-libraries-devel-${{ matrix.cuda-version }}.${{ matrix.cuda-arch }} \
+                         cuda-nvtx-${{ matrix.cuda-version }}.${{ matrix.cuda-arch }}
 
 #      - name: "Install HIP"
 #        run: |

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: "Install dependencies with yum"
         run: |
-          yum -y install zip opencl-headers ocl-icd tree
+          yum -y install zip opencl-headers ocl-icd
 
       - name: "Install CUDA"
         run: |
@@ -71,11 +71,6 @@ jobs:
           git apply $GITHUB_WORKSPACE/devtools/patches/cxx11_abi.patch
           git apply $GITHUB_WORKSPACE/devtools/patches/extras_require.patch
 
-      - name: "Tell me everything in the system"
-        run: |
-          cd /
-          tree || true
-
       - name: "Configure build with CMake"
         shell: bash -l {0}
         run: |
@@ -93,7 +88,7 @@ jobs:
             -DCMAKE_CUDA_HOST_COMPILER=c++ \
             -DOPENCL_INCLUDE_DIR=/usr/include/CL \
             -DOPENCL_LIBRARY=/usr/lib64/libOpenCL.so.1 \
-            -DUSE_SYSTEM_NVTX
+            -DUSE_SYSTEM_NVTX=1
 
       - name: "Build OpenMM-Torch"
         shell: bash -l {0}

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -1,7 +1,7 @@
 name: OpenMM-Torch-Build-Wheels
 
 env:
-  GIT_REVISION: '9ef733c071f70a77588ac0f076b1a7a0848a7550' # v1.5
+  GIT_REVISION: '9ef733c071f70a77588ac0f076b1a7a0848a7550'
   VERSION_SUFFIX: ''
 
 on:
@@ -86,7 +86,6 @@ jobs:
             -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
             -DCMAKE_CUDA_ARCHITECTURES=OFF \
             -DCMAKE_CUDA_HOST_COMPILER=c++ \
-            -DNN_BUILD_CUDA_LIB=OFF \
             -DOPENCL_INCLUDE_DIR=/usr/include/CL \
             -DOPENCL_LIBRARY=/usr/lib64/libOpenCL.so.1
 

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -26,7 +26,7 @@ jobs:
           - name: Linux x86
             os: ubuntu-latest
             requirements: linux
-            cuda-version: "12-4"
+            cuda-version: "12-6"
             cuda-arch: "x86_64"
             hip-version: "6"
 
@@ -84,11 +84,11 @@ jobs:
             -DOPENMM_DIR=${SITE_PACKAGES}/OpenMM.libs \
             -DTorch_DIR=${SITE_PACKAGES}/torch/share/cmake/Torch \
             -DCMAKE_CXX_FLAGS='-D_GLIBCXX_USE_CXX11_ABI=0' \
-            -DCMAKE_CUDA_ARCHITECTURES=OFF \
-            -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
-            -DCMAKE_CUDA_HOST_COMPILER=c++ \
-            -DOPENCL_INCLUDE_DIR=/usr/include/CL \
-            -DOPENCL_LIBRARY=/usr/lib64/libOpenCL.so.1
+#            -DCMAKE_CUDA_ARCHITECTURES=OFF \
+#            -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
+#            -DCMAKE_CUDA_HOST_COMPILER=c++ \
+#            -DOPENCL_INCLUDE_DIR=/usr/include/CL \
+#            -DOPENCL_LIBRARY=/usr/lib64/libOpenCL.so.1
 
       - name: "Build OpenMM-Torch"
         shell: bash -l {0}
@@ -109,7 +109,6 @@ jobs:
           python $GITHUB_WORKSPACE/devtools/scripts/add_plugins_and_headers.py "${SITE_PACKAGES}/OpenMM.libs" "Torch" "!CUDA" "!HIP"
           auditwheel repair -w fixed -L ".libs/lib" --plat manylinux_2_28_x86_64 openmmtorch*.whl \
             --exclude libOpenMM.so \
-            --exclude libOpenMMTorch.so \
             --exclude libOpenMMHIP.so \
             --exclude libOpenMMOpenCL.so \
             --exclude libOpenMMDrude.so \
@@ -178,7 +177,7 @@ jobs:
           export CUDA_VERSION=$(cut -d '-' -f1 <<< ${{ matrix.cuda-version }})
           pip install --pre -f python/dist/fixed openmmtorch[cuda${CUDA_VERSION}]
           ls -l python/dist/fixed
-          python -c "import openmmtorch; f = openmmtorch.TorchForce('tests/forces.pt')"
+          python -c "import openmmtorch; f = openmmtorch.TorchForce('tests/forces.pt')" || true
 
       - name: "Upload the wheel"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -86,6 +86,7 @@ jobs:
             -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
             -DCMAKE_CUDA_ARCHITECTURES=OFF \
             -DCMAKE_CUDA_HOST_COMPILER=c++ \
+            -DNN_BUILD_CUDA_LIB=OFF \
             -DOPENCL_INCLUDE_DIR=/usr/include/CL \
             -DOPENCL_LIBRARY=/usr/lib64/libOpenCL.so.1
 

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -1,7 +1,7 @@
 name: OpenMM-Torch-Build-Wheels
 
 env:
-  GIT_REVISION: 'wheels'
+  GIT_REVISION: '9ef733c071f70a77588ac0f076b1a7a0848a7550' # v1.5
   VERSION_SUFFIX: ''
 
 on:
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     container:
       image: quay.io/pypa/manylinux_2_28_x86_64
-    name: "${{ matrix.name }} ${{ matrix.python-version}}"
+    name: "${{ matrix.name }} ${{ matrix.python-version }}"
     strategy:
       matrix:
         python-version: ["3.10"]
@@ -64,7 +64,7 @@ jobs:
 
       - name: "Check out OpenMM-Torch source code"
         run: |
-          git clone https://github.com/peastman/openmm-torch.git
+          git clone https://github.com/openmm/openmm-torch.git
           cd openmm-torch
           git checkout $GIT_REVISION
           git apply $GITHUB_WORKSPACE/devtools/patches/cxx11_abi.patch
@@ -77,7 +77,7 @@ jobs:
           mkdir build
           cd build
           export SITE_PACKAGES=$(python -c 'import site; print(site.getsitepackages()[0])')
-          cmake .. \
+          cmake --trace-expand .. \
             -DCMAKE_INSTALL_PREFIX=${SITE_PACKAGES}/OpenMM.libs \
             -DOPENMM_DIR=${SITE_PACKAGES}/OpenMM.libs \
             -DTorch_DIR=${SITE_PACKAGES}/torch/share/cmake/Torch \

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -85,6 +85,7 @@ jobs:
             -DCMAKE_CXX_FLAGS='-D_GLIBCXX_USE_CXX11_ABI=0 -Wl,--allow-shlib-undefined' \
             -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
             -DCMAKE_CUDA_HOST_COMPILER=c++ \
+            -DCMAKE_PREFIX_PATH=/opt/rocm \
             -DOPENCL_INCLUDE_DIR=/usr/include/CL \
             -DOPENCL_LIBRARY=/usr/lib64/libOpenCL.so.1
 
@@ -152,17 +153,17 @@ jobs:
           python $GITHUB_WORKSPACE/devtools/scripts/add_plugins_and_headers.py "${SITE_PACKAGES}/OpenMM.libs" "Torch" "CUDA"
           mv OpenMM_Torch*.whl $GITHUB_WORKSPACE/openmm-torch/build/python/dist/fixed
 
-      - name: "Build HIP wheel"
-        shell: bash -l {0}
-        run: |
-          cd $GITHUB_WORKSPACE/devtools/hip
-          export OPENMM_VERSION=$(echo $(grep "OPENMM_VERSION:" $GITHUB_WORKSPACE/openmm/build/CMakeCache.txt) | cut -d '=' -f2)$VERSION_SUFFIX
-          export HIP_VERSION=${{ matrix.hip-version }}
-          python setup.py bdist_wheel
-          cd dist
-          export SITE_PACKAGES=$(python -c 'import site; print(site.getsitepackages()[0])')
-          python $GITHUB_WORKSPACE/devtools/scripts/add_plugins_and_headers.py "${SITE_PACKAGES}/OpenMM.libs" "Torch" "HIP"
-          mv OpenMM_Torch*.whl $GITHUB_WORKSPACE/openmm-torch/build/python/dist/fixed
+#      - name: "Build HIP wheel"
+#        shell: bash -l {0}
+#        run: |
+#          cd $GITHUB_WORKSPACE/devtools/hip
+#          export OPENMM_VERSION=$(echo $(grep "OPENMM_VERSION:" $GITHUB_WORKSPACE/openmm/build/CMakeCache.txt) | cut -d '=' -f2)$VERSION_SUFFIX
+#          export HIP_VERSION=${{ matrix.hip-version }}
+#          python setup.py bdist_wheel
+#          cd dist
+#          export SITE_PACKAGES=$(python -c 'import site; print(site.getsitepackages()[0])')
+#          python $GITHUB_WORKSPACE/devtools/scripts/add_plugins_and_headers.py "${SITE_PACKAGES}/OpenMM.libs" "Torch" "HIP"
+#          mv OpenMM_Torch*.whl $GITHUB_WORKSPACE/openmm-torch/build/python/dist/fixed
 
 #      - name: "Rename wheels"
 #        shell: bash -l {0}

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -174,7 +174,10 @@ jobs:
           source "${HOME}/test_env/bin/activate"
           cd openmm-torch/build
           export CUDA_VERSION=$(cut -d '-' -f1 <<< ${{ matrix.cuda-version }})
+          pip install pytest
           pip install --pre -f python/dist/fixed openmmtorch[cuda${CUDA_VERSION}]
+          python -m openmm.testInstallation
+          python -c "import openmm; print(*openmm.Platform.getPluginLoadFailures(), sep=\"\\n\")"
           python -c "import openmmtorch; f = openmmtorch.TorchForce('tests/forces.pt')"
           cd
           cd openmm-torch/python/tests

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -16,7 +16,8 @@ jobs:
   linux:
     runs-on: ${{ matrix.os }}
     container:
-      image: quay.io/pypa/manylinux_2_28_x86_64
+      # Use a version of manylinux with GCC 13, not 14, for NVCC compatibility
+      image: quay.io/pypa/manylinux_2_28_x86_64:2024.11.23-1
     name: "${{ matrix.name }} ${{ matrix.python-version }}"
     strategy:
       matrix:
@@ -47,8 +48,7 @@ jobs:
 
       - name: "Install dependencies with yum"
         run: |
-          apt install -y zip opencl-headers ocl-icd gcc-13
-          update-alternatives --query gcc
+          yum -y install zip opencl-headers ocl-icd
 
       - name: "Install CUDA"
         run: |

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -177,10 +177,7 @@ jobs:
           pip install pytest
           pip install --pre -f python/dist/fixed openmmtorch[cuda${CUDA_VERSION}]
           python -m openmm.testInstallation
-          python -c "import openmm; print(*openmm.Platform.getPluginLoadFailures(), sep=\"\\n\")"
-          python -c "import openmmtorch; f = openmmtorch.TorchForce('tests/forces.pt')"
-          cd
-          cd openmm-torch/python/tests
+          cd ../python/tests
           for test_file in Test*.py; do pytest "${test_file}"; done
 
       - name: "Upload the wheel"

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -105,9 +105,8 @@ jobs:
           pip wheel -w dist .
           cd dist
           export SITE_PACKAGES=$(python -c 'import site; print(site.getsitepackages()[0])')
-          export LD_LIBRARY_PATH=${SITE_PACKAGES}/OpenMM.libs/lib
           python $GITHUB_WORKSPACE/devtools/scripts/add_plugins_and_headers.py "${SITE_PACKAGES}/OpenMM.libs" "Torch" "!CUDA" "!HIP"
-          auditwheel repair -w fixed -L ".libs/lib" --plat manylinux_2_28_x86_64 openmmtorch*.whl \
+          auditwheel repair -w fixed --plat manylinux_2_28_x86_64 openmmtorch*.whl \
             --exclude libOpenMM.so \
             --exclude libOpenMMHIP.so \
             --exclude libOpenMMOpenCL.so \

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -60,7 +60,7 @@ jobs:
       - name: "See what's available in cuda"
         shell: bash -l {0}
         run: |
-          find / -iname "cuda" || true
+          find / -iname '*cuda*' || true
           false
 
 #      - name: "Install HIP"

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -106,7 +106,7 @@ jobs:
           cd dist
           export SITE_PACKAGES=$(python -c 'import site; print(site.getsitepackages()[0])')
           export LD_LIBRARY_PATH=${SITE_PACKAGES}/OpenMM.libs/lib
-          # python $GITHUB_WORKSPACE/devtools/scripts/add_plugins_and_headers.py "${SITE_PACKAGES}/OpenMM.libs" "Torch" "!CUDA" "!HIP"
+          python $GITHUB_WORKSPACE/devtools/scripts/add_plugins_and_headers.py "${SITE_PACKAGES}/OpenMM.libs" "Torch" "!CUDA" "!HIP"
           auditwheel repair -w fixed -L ".libs/lib" --plat manylinux_2_28_x86_64 openmmtorch*.whl \
             --exclude libOpenMM.so \
             --exclude libOpenMMHIP.so \
@@ -135,7 +135,7 @@ jobs:
             --exclude libnvrtc.so.12 \
             --exclude libnvJitLink.so.12 \
             --exclude libhiprtc.so.6 \
-            --exclude libamdhip64.so.6 || true
+            --exclude libamdhip64.so.6
 
 #      - name: "Build CUDA wheel"
 #        shell: bash -l {0}

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -119,6 +119,7 @@ jobs:
             --exclude libtorch.so \
             --exclude libtorch_cpu.so \
             --exclude libtorch_gpu.so \
+            --exclude libtorch_cuda.so \
             --exclude libc10.so \
             --exclude libcuda.so.1 \
             --exclude libcudart.so.12 \

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -44,7 +44,7 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install -v --pre -r devtools/requirements/${{ matrix.requirements }}.txt
-          pip install -v torch==2.6
+          pip install -v torch==2.3
 
       - name: "Install dependencies with yum"
         run: |
@@ -79,7 +79,7 @@ jobs:
           mkdir build
           cd build
           export SITE_PACKAGES=$(python -c 'import site; print(site.getsitepackages()[0])')
-          cmake --trace-expand .. \
+          cmake .. \
             -DCMAKE_INSTALL_PREFIX=${SITE_PACKAGES}/OpenMM.libs \
             -DOPENMM_DIR=${SITE_PACKAGES}/OpenMM.libs \
             -DTorch_DIR=${SITE_PACKAGES}/torch/share/cmake/Torch \
@@ -88,8 +88,7 @@ jobs:
             -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
             -DCMAKE_CUDA_HOST_COMPILER=c++ \
             -DOPENCL_INCLUDE_DIR=/usr/include/CL \
-            -DOPENCL_LIBRARY=/usr/lib64/libOpenCL.so.1 \
-            -DUSE_SYSTEM_NVTX=1
+            -DOPENCL_LIBRARY=/usr/lib64/libOpenCL.so.1
 
       - name: "Build OpenMM-Torch"
         shell: bash -l {0}
@@ -179,11 +178,11 @@ jobs:
           export CUDA_VERSION=$(cut -d '-' -f1 <<< ${{ matrix.cuda-version }})
           pip install --pre -f python/dist/fixed openmmtorch[cuda${CUDA_VERSION}]
           ls -l python/dist/fixed
-#          python -c "import openmmtorch; f = openmmtorch.TorchForce('tests/forces.pt')"
+          python -c "import openmmtorch; f = openmmtorch.TorchForce('tests/forces.pt')"
 
-          # - name: "Upload the wheel"
-          #   uses: actions/upload-artifact@v4
-          #   with:
-          #     name: openmm-torch-wheel-linux-${{matrix.python-version}}
-          #     path: openmm-torch/build/python/dist/fixed
-          #     retention-days: 10
+      - name: "Upload the wheel"
+        uses: actions/upload-artifact@v4
+        with:
+          name: openmm-torch-wheel-linux-${{matrix.python-version}}
+          path: openmm-torch/build/python/dist/fixed
+          retention-days: 10

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -84,7 +84,6 @@ jobs:
             -DOPENMM_DIR=${SITE_PACKAGES}/OpenMM.libs \
             -DTorch_DIR=${SITE_PACKAGES}/torch/share/cmake/Torch \
             -DCMAKE_CXX_FLAGS='-D_GLIBCXX_USE_CXX11_ABI=0' \
-#            -DCMAKE_CUDA_ARCHITECTURES=OFF \
             -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
             -DCMAKE_CUDA_HOST_COMPILER=c++ \
             -DOPENCL_INCLUDE_DIR=/usr/include/CL \

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -84,6 +84,7 @@ jobs:
             -DTorch_DIR=${SITE_PACKAGES}/torch/share/cmake/Torch \
             -DCMAKE_CXX_FLAGS='-D_GLIBCXX_USE_CXX11_ABI=0' \
             -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
+            -DCMAKE_CUDA_ARCHITECTURES=OFF \
             -DCMAKE_CUDA_HOST_COMPILER=c++ \
             -DOPENCL_INCLUDE_DIR=/usr/include/CL \
             -DOPENCL_LIBRARY=/usr/lib64/libOpenCL.so.1

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -44,7 +44,6 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install -v --pre -r devtools/requirements/${{ matrix.requirements }}.txt
-          pip install -v torch==2.6
 
       - name: "Install dependencies with yum"
         run: |

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -101,14 +101,14 @@ jobs:
         run: |
           cd openmm-torch/build/python
           export CUDA_VERSION=$(cut -d '-' -f1 <<< ${{ matrix.cuda-version }})
+          export HIP_VERSION=${{ matrix.hip-version }}
           pip wheel -w dist .
-          export LD_LIBRARY_PATH=${HOME}/openmm-install/lib
           cd dist
           export SITE_PACKAGES=$(python -c 'import site; print(site.getsitepackages()[0])')
-          python $GITHUB_WORKSPACE/devtools/scripts/add_plugins_and_headers.py "${SITE_PACKAGES}/OpenMM.libs" "Torch" "!CUDA" "!HIP"
+          export LD_LIBRARY_PATH=${SITE_PACKAGES}/OpenMM.libs/lib
+          # python $GITHUB_WORKSPACE/devtools/scripts/add_plugins_and_headers.py "${SITE_PACKAGES}/OpenMM.libs" "Torch" "!CUDA" "!HIP"
           auditwheel repair -w fixed -L ".libs/lib" --plat manylinux_2_28_x86_64 openmmtorch*.whl \
             --exclude libOpenMM.so \
-            --exclude libOpenMMTorch.so \
             --exclude libOpenMMHIP.so \
             --exclude libOpenMMOpenCL.so \
             --exclude libOpenMMDrude.so \
@@ -167,21 +167,22 @@ jobs:
 #        run: |
 #          python $GITHUB_WORKSPACE/devtools/scripts/rename_wheels.py $GITHUB_WORKSPACE/openmm-torch/build/python/dist/fixed
 #
-#      - name: "Test the wheel"
-#        shell: bash -l {0}
-#        run: |
-#          set -x
-#          python -m venv "${HOME}/test_env"
-#          source "${HOME}/test_env/bin/activate"
-#          cd openmm-torch/build
-#          export CUDA_VERSION=$(cut -d '-' -f1 <<< ${{ matrix.cuda-version }})
-#          pip install --pre -f python/dist/fixed openmmtorch[cuda${CUDA_VERSION}]
-#          ls -l python/dist/fixed
-#          python -c "import openmmtorch; f = openmmtorch.TorchForce('tests/forces.pt')" || true
+      - name: "Test the wheel"
+        shell: bash -l {0}
+        run: |
+          set -x
+          python -m venv "${HOME}/test_env"
+          source "${HOME}/test_env/bin/activate"
+          cd openmm-torch/build
+          #export CUDA_VERSION=$(cut -d '-' -f1 <<< ${{ matrix.cuda-version }})
+          #pip install --pre -f python/dist/fixed openmmtorch[cuda${CUDA_VERSION}]
+          pip install --pre -f python/dist/fixed openmmtorch
+          ls -l python/dist/fixed
+          python -c "import openmmtorch; f = openmmtorch.TorchForce('tests/forces.pt')" || true
 
       - name: "Upload the wheel"
         uses: actions/upload-artifact@v4
         with:
           name: openmm-torch-wheel-linux-${{matrix.python-version}}
-          path: openmm-torch/build/python/dist
+          path: openmm-torch/build/python/dist/fixed
           retention-days: 10

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -108,6 +108,7 @@ jobs:
           python $GITHUB_WORKSPACE/devtools/scripts/add_plugins_and_headers.py "${SITE_PACKAGES}/OpenMM.libs" "Torch" "!CUDA" "!HIP"
           auditwheel repair -w fixed --plat manylinux_2_28_x86_64 openmmtorch*.whl \
             --exclude libOpenMM.so \
+            --exclude libOpenMMTorch.so \
             --exclude libOpenMMHIP.so \
             --exclude libOpenMMOpenCL.so \
             --exclude libOpenMMDrude.so \

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -85,10 +85,10 @@ jobs:
             -DTorch_DIR=${SITE_PACKAGES}/torch/share/cmake/Torch \
             -DCMAKE_CXX_FLAGS='-D_GLIBCXX_USE_CXX11_ABI=0' \
 #            -DCMAKE_CUDA_ARCHITECTURES=OFF \
-#            -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
-#            -DCMAKE_CUDA_HOST_COMPILER=c++ \
-#            -DOPENCL_INCLUDE_DIR=/usr/include/CL \
-#            -DOPENCL_LIBRARY=/usr/lib64/libOpenCL.so.1
+            -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
+            -DCMAKE_CUDA_HOST_COMPILER=c++ \
+            -DOPENCL_INCLUDE_DIR=/usr/include/CL \
+            -DOPENCL_LIBRARY=/usr/lib64/libOpenCL.so.1
 
       - name: "Build OpenMM-Torch"
         shell: bash -l {0}

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -82,7 +82,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=${SITE_PACKAGES}/OpenMM.libs \
             -DOPENMM_DIR=${SITE_PACKAGES}/OpenMM.libs \
             -DTorch_DIR=${SITE_PACKAGES}/torch/share/cmake/Torch \
-            -DCMAKE_CXX_FLAGS='-D_GLIBCXX_USE_CXX11_ABI=0 -lcuda' \
+            -DCMAKE_CXX_FLAGS='-D_GLIBCXX_USE_CXX11_ABI=0 -Wl,--allow-shlib-undefined' \
             -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
             -DCMAKE_CUDA_HOST_COMPILER=c++ \
             -DOPENCL_INCLUDE_DIR=/usr/include/CL \

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -20,7 +20,7 @@ jobs:
     name: "${{ matrix.name }} ${{ matrix.python-version }}"
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         include:
           - name: Linux x86
             os: ubuntu-latest

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -108,6 +108,7 @@ jobs:
           python $GITHUB_WORKSPACE/devtools/scripts/add_plugins_and_headers.py "${SITE_PACKAGES}/OpenMM.libs" "Torch" "!CUDA" "!HIP"
           auditwheel repair -w fixed -L ".libs/lib" --plat manylinux_2_28_x86_64 openmmtorch*.whl \
             --exclude libOpenMM.so \
+            --exclude libOpenMMTorch.so \
             --exclude libOpenMMHIP.so \
             --exclude libOpenMMOpenCL.so \
             --exclude libOpenMMDrude.so \
@@ -134,20 +135,20 @@ jobs:
             --exclude libnvrtc.so.12 \
             --exclude libnvJitLink.so.12 \
             --exclude libhiprtc.so.6 \
-            --exclude libamdhip64.so.6
+            --exclude libamdhip64.so.6 || true
 
-      - name: "Build CUDA wheel"
-        shell: bash -l {0}
-        run: |
-          cd $GITHUB_WORKSPACE/devtools/cuda
-          export OPENMM_TORCH_VERSION=$(echo $(grep "OPENMM_TORCH_VERSION:" $GITHUB_WORKSPACE/openmm-torch/build/CMakeCache.txt) | cut -d '=' -f2)$VERSION_SUFFIX
-          export CUDA_VERSION=$(cut -d '-' -f1 <<< ${{ matrix.cuda-version }})
-          export HIP_VERSION=${{ matrix.hip-version }}
-          pip wheel -w dist .
-          cd dist
-          export SITE_PACKAGES=$(python -c 'import site; print(site.getsitepackages()[0])')
-          python $GITHUB_WORKSPACE/devtools/scripts/add_plugins_and_headers.py "${SITE_PACKAGES}/OpenMM.libs" "Torch" "CUDA"
-          mv OpenMM_Torch*.whl $GITHUB_WORKSPACE/openmm-torch/build/python/dist/fixed
+#      - name: "Build CUDA wheel"
+#        shell: bash -l {0}
+#        run: |
+#          cd $GITHUB_WORKSPACE/devtools/cuda
+#          export OPENMM_TORCH_VERSION=$(echo $(grep "OPENMM_TORCH_VERSION:" $GITHUB_WORKSPACE/openmm-torch/build/CMakeCache.txt) | cut -d '=' -f2)$VERSION_SUFFIX
+#          export CUDA_VERSION=$(cut -d '-' -f1 <<< ${{ matrix.cuda-version }})
+#          export HIP_VERSION=${{ matrix.hip-version }}
+#          pip wheel -w dist .
+#          cd dist
+#          export SITE_PACKAGES=$(python -c 'import site; print(site.getsitepackages()[0])')
+#          python $GITHUB_WORKSPACE/devtools/scripts/add_plugins_and_headers.py "${SITE_PACKAGES}/OpenMM.libs" "Torch" "CUDA"
+#          mv OpenMM_Torch*.whl $GITHUB_WORKSPACE/openmm-torch/build/python/dist/fixed
 #
 #      - name: "Build HIP wheel"
 #        shell: bash -l {0}
@@ -166,21 +167,21 @@ jobs:
 #        run: |
 #          python $GITHUB_WORKSPACE/devtools/scripts/rename_wheels.py $GITHUB_WORKSPACE/openmm-torch/build/python/dist/fixed
 #
-      - name: "Test the wheel"
-        shell: bash -l {0}
-        run: |
-          set -x
-          python -m venv "${HOME}/test_env"
-          source "${HOME}/test_env/bin/activate"
-          cd openmm-torch/build
-          export CUDA_VERSION=$(cut -d '-' -f1 <<< ${{ matrix.cuda-version }})
-          pip install --pre -f python/dist/fixed openmmtorch[cuda${CUDA_VERSION}]
-          ls -l python/dist/fixed
-          python -c "import openmmtorch; f = openmmtorch.TorchForce('tests/forces.pt')" || true
+#      - name: "Test the wheel"
+#        shell: bash -l {0}
+#        run: |
+#          set -x
+#          python -m venv "${HOME}/test_env"
+#          source "${HOME}/test_env/bin/activate"
+#          cd openmm-torch/build
+#          export CUDA_VERSION=$(cut -d '-' -f1 <<< ${{ matrix.cuda-version }})
+#          pip install --pre -f python/dist/fixed openmmtorch[cuda${CUDA_VERSION}]
+#          ls -l python/dist/fixed
+#          python -c "import openmmtorch; f = openmmtorch.TorchForce('tests/forces.pt')" || true
 
       - name: "Upload the wheel"
         uses: actions/upload-artifact@v4
         with:
           name: openmm-torch-wheel-linux-${{matrix.python-version}}
-          path: openmm-torch/build/python/dist/fixed
+          path: openmm-torch/build/python/dist
           retention-days: 10

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -57,13 +57,6 @@ jobs:
                          cuda-libraries-devel-${{ matrix.cuda-version }}.${{ matrix.cuda-arch }} \
                          cuda-nvtx-${{ matrix.cuda-version }}.${{ matrix.cuda-arch }}
 
-      - name: "See what's available in cuda"
-        shell: bash -l {0}
-        run: |
-          readlink -f /usr/local/cuda
-          find -L $(readlink -f /usr/local/cuda)
-          false
-
 #      - name: "Install HIP"
 #        run: |
 #          yum install -y epel-release
@@ -89,9 +82,8 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=${SITE_PACKAGES}/OpenMM.libs \
             -DOPENMM_DIR=${SITE_PACKAGES}/OpenMM.libs \
             -DTorch_DIR=${SITE_PACKAGES}/torch/share/cmake/Torch \
-            -DCMAKE_CXX_FLAGS='-D_GLIBCXX_USE_CXX11_ABI=0' \
+            -DCMAKE_CXX_FLAGS='-D_GLIBCXX_USE_CXX11_ABI=0 -lcuda' \
             -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc \
-            -DCMAKE_CUDA_ARCHITECTURES=OFF \
             -DCMAKE_CUDA_HOST_COMPILER=c++ \
             -DOPENCL_INCLUDE_DIR=/usr/include/CL \
             -DOPENCL_LIBRARY=/usr/lib64/libOpenCL.so.1

--- a/.github/workflows/BuildWheels.yml
+++ b/.github/workflows/BuildWheels.yml
@@ -57,11 +57,11 @@ jobs:
                          cuda-libraries-devel-${{ matrix.cuda-version }}.${{ matrix.cuda-arch }} \
                          cuda-nvtx-${{ matrix.cuda-version }}.${{ matrix.cuda-arch }}
 
-#      - name: "Install HIP"
-#        run: |
-#          yum install -y epel-release
-#          yum install -y https://repo.radeon.com/amdgpu-install/6.2.2/el/8.10/amdgpu-install-6.2.60202-1.el8.noarch.rpm
-#          yum install -y rocm-device-libs hip-devel hip-runtime-amd hipcc
+      - name: "Install HIP"
+        run: |
+          yum install -y epel-release
+          yum install -y https://repo.radeon.com/amdgpu-install/6.2.2/el/8.10/amdgpu-install-6.2.60202-1.el8.noarch.rpm
+          yum install -y rocm-device-libs hip-devel hip-runtime-amd hipcc
 
       - name: "Check out OpenMM-Torch source code"
         run: |
@@ -99,6 +99,7 @@ jobs:
         shell: bash -l {0}
         run: |
           cd openmm-torch/build/python
+          export OPENMM_TORCH_VERSION=$(echo $(grep "OPENMM_TORCH_VERSION:" $GITHUB_WORKSPACE/openmm-torch/build/CMakeCache.txt) | cut -d '=' -f2)$VERSION_SUFFIX
           export CUDA_VERSION=$(cut -d '-' -f1 <<< ${{ matrix.cuda-version }})
           export HIP_VERSION=${{ matrix.hip-version }}
           pip wheel -w dist .
@@ -138,31 +139,31 @@ jobs:
             --exclude libhiprtc.so.6 \
             --exclude libamdhip64.so.6
 
-#      - name: "Build CUDA wheel"
-#        shell: bash -l {0}
-#        run: |
-#          cd $GITHUB_WORKSPACE/devtools/cuda
-#          export OPENMM_TORCH_VERSION=$(echo $(grep "OPENMM_TORCH_VERSION:" $GITHUB_WORKSPACE/openmm-torch/build/CMakeCache.txt) | cut -d '=' -f2)$VERSION_SUFFIX
-#          export CUDA_VERSION=$(cut -d '-' -f1 <<< ${{ matrix.cuda-version }})
-#          export HIP_VERSION=${{ matrix.hip-version }}
-#          pip wheel -w dist .
-#          cd dist
-#          export SITE_PACKAGES=$(python -c 'import site; print(site.getsitepackages()[0])')
-#          python $GITHUB_WORKSPACE/devtools/scripts/add_plugins_and_headers.py "${SITE_PACKAGES}/OpenMM.libs" "Torch" "CUDA"
-#          mv OpenMM_Torch*.whl $GITHUB_WORKSPACE/openmm-torch/build/python/dist/fixed
-#
-#      - name: "Build HIP wheel"
-#        shell: bash -l {0}
-#        run: |
-#          cd $GITHUB_WORKSPACE/devtools/hip
-#          export OPENMM_VERSION=$(echo $(grep "OPENMM_VERSION:" $GITHUB_WORKSPACE/openmm/build/CMakeCache.txt) | cut -d '=' -f2)$VERSION_SUFFIX
-#          export HIP_VERSION=${{ matrix.hip-version }}
-#          python setup.py bdist_wheel
-#          cd dist
-#          export SITE_PACKAGES=$(python -c 'import site; print(site.getsitepackages()[0])')
-#          python $GITHUB_WORKSPACE/devtools/scripts/add_plugins_and_headers.py "${SITE_PACKAGES}/OpenMM.libs" "Torch" "HIP"
-#          mv OpenMM_Torch*.whl $GITHUB_WORKSPACE/openmm-torch/build/python/dist/fixed
-#
+      - name: "Build CUDA wheel"
+        shell: bash -l {0}
+        run: |
+          cd $GITHUB_WORKSPACE/devtools/cuda
+          export OPENMM_TORCH_VERSION=$(echo $(grep "OPENMM_TORCH_VERSION:" $GITHUB_WORKSPACE/openmm-torch/build/CMakeCache.txt) | cut -d '=' -f2)$VERSION_SUFFIX
+          export CUDA_VERSION=$(cut -d '-' -f1 <<< ${{ matrix.cuda-version }})
+          export HIP_VERSION=${{ matrix.hip-version }}
+          pip wheel -w dist .
+          cd dist
+          export SITE_PACKAGES=$(python -c 'import site; print(site.getsitepackages()[0])')
+          python $GITHUB_WORKSPACE/devtools/scripts/add_plugins_and_headers.py "${SITE_PACKAGES}/OpenMM.libs" "Torch" "CUDA"
+          mv OpenMM_Torch*.whl $GITHUB_WORKSPACE/openmm-torch/build/python/dist/fixed
+
+      - name: "Build HIP wheel"
+        shell: bash -l {0}
+        run: |
+          cd $GITHUB_WORKSPACE/devtools/hip
+          export OPENMM_VERSION=$(echo $(grep "OPENMM_VERSION:" $GITHUB_WORKSPACE/openmm/build/CMakeCache.txt) | cut -d '=' -f2)$VERSION_SUFFIX
+          export HIP_VERSION=${{ matrix.hip-version }}
+          python setup.py bdist_wheel
+          cd dist
+          export SITE_PACKAGES=$(python -c 'import site; print(site.getsitepackages()[0])')
+          python $GITHUB_WORKSPACE/devtools/scripts/add_plugins_and_headers.py "${SITE_PACKAGES}/OpenMM.libs" "Torch" "HIP"
+          mv OpenMM_Torch*.whl $GITHUB_WORKSPACE/openmm-torch/build/python/dist/fixed
+
 #      - name: "Rename wheels"
 #        shell: bash -l {0}
 #        run: |

--- a/devtools/requirements/linux.txt
+++ b/devtools/requirements/linux.txt
@@ -1,4 +1,4 @@
-openmm
+openmm[cuda12]
 pybind11
 cmake
 swig
@@ -7,3 +7,4 @@ delocate
 wheel
 auditwheel
 setuptools
+torch

--- a/devtools/requirements/linux.txt
+++ b/devtools/requirements/linux.txt
@@ -1,4 +1,4 @@
-openmm
+openmm[cuda12]
 pybind11
 cmake
 swig

--- a/devtools/requirements/linux.txt
+++ b/devtools/requirements/linux.txt
@@ -1,4 +1,4 @@
-openmm[cuda12]
+openmm
 pybind11
 cmake
 swig

--- a/devtools/scripts/add_plugins_and_headers.py
+++ b/devtools/scripts/add_plugins_and_headers.py
@@ -23,7 +23,7 @@ else:
             print('    ignorefiles:', ignorefiles)
         return ignorefiles
 for filename in os.listdir('.'):
-    if (filename.startswith('openmmtorch') or filename.startswith('OpenMM-Torch')) and filename.endswith('.whl'):
+    if (filename.startswith('openmmtorch') or filename.startswith('OpenMM_Torch')) and filename.endswith('.whl'):
         print('filename:', filename)
         with wheeltools.InWheel(filename, filename):
             shutil.copytree(join(install_dir, 'lib'), 'OpenMM.libs/lib', dirs_exist_ok=True, ignore=ignore)

--- a/devtools/scripts/add_plugins_and_headers.py
+++ b/devtools/scripts/add_plugins_and_headers.py
@@ -44,8 +44,5 @@ for filename in os.listdir('.'):
                     subprocess.run(['patchelf', '--remove-rpath', soname], check=True)
                     subprocess.run(['patchelf', '--force-rpath', '--set-rpath', ':'.join(new_rpath), soname], check=True)
             for soname in os.listdir('OpenMM.libs/lib/plugins'):
-                # These need an rpath to look in the parent directory for
-                # libOpenMMTorch.so; it doesn't get loaded by _openmm.*.so with
-                # libOpenMM.so and for some reason it can't then be found by the
-                # plugins...
-                subprocess.run(['patchelf', '--force-rpath', '--set-rpath', '$ORIGIN/..', os.path.join('OpenMM.libs/lib/plugins', soname)])
+                # These need an rpath that doesn't get added automatically
+                subprocess.run(['patchelf', '--force-rpath', '--set-rpath', '$ORIGIN/..:$ORIGIN/../../../torch/lib', os.path.join('OpenMM.libs/lib/plugins', soname)])

--- a/devtools/scripts/add_plugins_and_headers.py
+++ b/devtools/scripts/add_plugins_and_headers.py
@@ -43,3 +43,9 @@ for filename in os.listdir('.'):
                     print(f'patching {soname!r}: rpath {rpath} -> {new_rpath}')
                     subprocess.run(['patchelf', '--remove-rpath', soname], check=True)
                     subprocess.run(['patchelf', '--force-rpath', '--set-rpath', ':'.join(new_rpath), soname], check=True)
+            for soname in os.listdir('OpenMM.libs/lib/plugins'):
+                # These need an rpath to look in the parent directory for
+                # libOpenMMTorch.so; it doesn't get loaded by _openmm.*.so with
+                # libOpenMM.so and for some reason it can't then be found by the
+                # plugins...
+                subprocess.run(['patchelf', '--force-rpath', '--set-rpath', '$ORIGIN/..', os.path.join('OpenMM.libs/lib/plugins', soname)])

--- a/devtools/scripts/add_plugins_and_headers.py
+++ b/devtools/scripts/add_plugins_and_headers.py
@@ -22,8 +22,7 @@ else:
             print('    ignorefiles:', ignorefiles)
         return ignorefiles
 for filename in os.listdir('.'):
-    if filename.endswith('.whl'):
+    if filename.startswith("openmmtorch") and filename.endswith('.whl'):
         print('filename:', filename)
         with wheeltools.InWheel(filename, filename):
-            shutil.copytree(join(install_dir, 'lib'), 'OpenMM.libs/lib', dirs_exist_ok=True, ignore=ignore)
-            # shutil.copytree(join(install_dir, 'include'), 'OpenMM.libs/include', dirs_exist_ok=True)
+            shutil.copytree(join(install_dir, 'lib'), 'openmmtorch.libs/lib', dirs_exist_ok=True, ignore=ignore)

--- a/devtools/scripts/add_plugins_and_headers.py
+++ b/devtools/scripts/add_plugins_and_headers.py
@@ -23,7 +23,7 @@ else:
             print('    ignorefiles:', ignorefiles)
         return ignorefiles
 for filename in os.listdir('.'):
-    if filename.startswith('openmmtorch') and filename.endswith('.whl'):
+    if (filename.startswith('openmmtorch') or filename.startswith('OpenMM-Torch')) and filename.endswith('.whl'):
         print('filename:', filename)
         with wheeltools.InWheel(filename, filename):
             shutil.copytree(join(install_dir, 'lib'), 'OpenMM.libs/lib', dirs_exist_ok=True, ignore=ignore)

--- a/devtools/scripts/add_plugins_and_headers.py
+++ b/devtools/scripts/add_plugins_and_headers.py
@@ -2,6 +2,7 @@ from delocate import wheeltools
 from os.path import join, isdir
 import os
 import shutil
+import subprocess
 import sys
 
 install_dir = sys.argv[1]
@@ -22,7 +23,23 @@ else:
             print('    ignorefiles:', ignorefiles)
         return ignorefiles
 for filename in os.listdir('.'):
-    if filename.startswith("openmmtorch") and filename.endswith('.whl'):
+    if filename.startswith('openmmtorch') and filename.endswith('.whl'):
         print('filename:', filename)
         with wheeltools.InWheel(filename, filename):
-            shutil.copytree(join(install_dir, 'lib'), 'openmmtorch.libs/lib', dirs_exist_ok=True, ignore=ignore)
+            shutil.copytree(join(install_dir, 'lib'), 'OpenMM.libs/lib', dirs_exist_ok=True, ignore=ignore)
+            site_packages = os.path.dirname(os.path.realpath(install_dir))
+            for soname in os.listdir('.'):
+                if soname.startswith('_openmmtorch') and soname.endswith('.so'):
+                    # auditwheel doesn't understand that we should depend on
+                    # libraries in OpenMM.libs (not openmmtorch.libs) so the
+                    # _openmmtorch compiled library is patched up manually.
+                    result = subprocess.run(['patchelf', '--print-rpath', soname], check=True, capture_output=True)
+                    rpath = result.stdout.decode().strip().split(':')
+                    new_rpath = []
+                    for rpath_entry in rpath:
+                        if not rpath_entry:
+                            continue
+                        new_rpath.append(os.path.join('$ORIGIN', os.path.relpath(os.path.realpath(rpath_entry), site_packages)))
+                    print(f'patching {soname!r}: rpath {rpath} -> {new_rpath}')
+                    subprocess.run(['patchelf', '--remove-rpath', soname], check=True)
+                    subprocess.run(['patchelf', '--force-rpath', '--set-rpath', ':'.join(new_rpath), soname], check=True)


### PR DESCRIPTION
I managed to get some wheels built.  The problem you mentioned at pytorch/pytorch#139108 turned out to just be that you have to install the `cuda-nvtx` package separately from the repository.  It wasn't found simply because it wasn't installed.

I encountered many other problems after this, though.  I spent a while fighting with `auditwheel` to fix the libraries in the wheel properly before giving up.  Specifically, it doesn't understand that openmm-torch wants to get libraries from and put libraries in `OpenMM.libs/` and instead wants to work only with `openmmtorch.libs/`.  In the end, `add_plugins_and_headers.py` is now hacked up to manually call `patchelf`.  There is probably a better way of doing all of this.  If you know how, the hack I added can be removed, but it does work.

I did not try very much to get HIP working.  I'm not too familiar with building for that platform yet and I don't know how we run tests for it.  If it's something you still want me to look into in the future, I can try to make it work.

The tests appear to run although all of the CUDA tests get skipped because there's not actually hardware support in the container.  I manually tested the 3.10 and 3.13 wheels on a machine with an NVIDIA GPU and all of the CUDA tests run successfully.  The script here skips the test requiring NNPOps because I don't see that on PyPI so I'm assuming it's not there.

I realize this is hacked together in many ways, but hopefully it's a starting point, because it does actually produce wheels that appear, for me, to work.